### PR TITLE
provide MFA in add_existing_child, make after_terminate work

### DIFF
--- a/src/gen_tracker.erl
+++ b/src/gen_tracker.erl
@@ -159,6 +159,11 @@ wait(Zone) ->
   gen_server:call(Zone, wait).
 
 
+
+
+add_existing_child(Tracker, {Pid, {_Name, _MFA, _RestartType, _Shutdown, worker, _Mods}} = ChildSpec) when is_pid(Pid) ->
+  gen_server:call(Tracker, {add_existing_child, ChildSpec});
+
 add_existing_child(Tracker, {_Name, Pid, worker, _} = ChildSpec) when is_pid(Pid) ->
   gen_server:call(Tracker, {add_existing_child, ChildSpec}).
 
@@ -348,25 +353,13 @@ handle_call({delete_child, Name}, _From, #tracker{zone = Zone} = Tracker) ->
       {reply, {error, no_child}, Tracker}
   end;
 
-handle_call({add_existing_child, {Name, Pid, worker, Mods}}, _From, #tracker{zone = Zone} = Tracker) ->
-  case ets:lookup(Zone, Name) of
-    [#entry{pid = Pid2}] ->
-      {reply, {error, {already_started, Pid2}}, Tracker};
-    [] ->
-      Ref = erlang:monitor(process,Pid),
-      ets:insert(Zone, #entry{name = Name, mfa = undefined, sub_pid = Pid, pid = Pid, restart_type = temporary,
-        shutdown = 200, child_type = worker, mods = Mods, ref = Ref}),
 
-      Parent = self(),
-      proc_lib:spawn_link(fun() ->
-        put(name, {gen_tracker,Zone,proxy,Name}),
-        process_flag(trap_exit,true),
-        ets:update_element(Zone, Name, {#entry.sub_pid, self()}),
-        erlang:monitor(process,Pid),
-        proc_lib:hibernate(?MODULE, child_monitoring, [Zone, Name, Pid, Parent])
-      end),
-      {reply, {ok, Pid}, Tracker}
-  end;
+handle_call({add_existing_child, {Pid, {Name, MFA, RestartType, Shutdown, worker, Mods}}}, _From, #tracker{zone = Zone} = Tracker) ->
+  do_add_existing_child(Pid, {Name, MFA, RestartType, Shutdown, worker, Mods}, Tracker);
+
+handle_call({add_existing_child, {Name, Pid, worker, Mods}}, _From, #tracker{zone = Zone} = Tracker) ->
+  do_add_existing_child(Pid, {Name, undefined, temporary, 200, worker, Mods}, Tracker);
+
 
 handle_call(stop, _From, #tracker{} = Tracker) ->
   {stop, normal, ok, Tracker};
@@ -483,6 +476,29 @@ which_children(Zone) ->
   ets:select(Zone, ets:fun2ms(fun(#entry{name = Name, pid = Pid, child_type = CT, mods = Mods}) ->
     {Name, Pid, CT, Mods}
   end)).
+
+
+
+do_add_existing_child(Pid, {Name, MFA, _RestartType, _Shutdown, worker, Mods}, #tracker{zone = Zone} = Tracker) ->
+  case ets:lookup(Zone, Name) of
+    [#entry{pid = Pid2}] ->
+      {reply, {error, {already_started, Pid2}}, Tracker};
+    [] ->
+      Ref = erlang:monitor(process,Pid),
+      ets:insert(Zone, #entry{name = Name, mfa = MFA, sub_pid = Pid, pid = Pid, restart_type = temporary,
+        shutdown = 200, child_type = worker, mods = Mods, ref = Ref}),
+
+      Parent = self(),
+      proc_lib:spawn_link(fun() ->
+        put(name, {gen_tracker,Zone,proxy,Name}),
+        process_flag(trap_exit,true),
+        ets:update_element(Zone, Name, {#entry.sub_pid, self()}),
+        erlang:monitor(process,Pid),
+        proc_lib:hibernate(?MODULE, child_monitoring, [Zone, Name, Pid, Parent])
+      end),
+      {reply, {ok, Pid}, Tracker}
+  end.
+
 
 % restart_later(Zone, #entry{name = Name, restart_timer = OldTimer, restart_delay = OldDelay} = Entry) ->
 %   case OldTimer of


### PR DESCRIPTION
Currently processes added via `add_existing_child` wouldn't trigger `after_terminate` callback, simply because gen_tracker doesn't know which module they use, where to search callback.

I've added a way to add existing pid with full spec, where MFA is included, and gen_tracker can lookup for `after_terminate` callback.